### PR TITLE
Add erc2981

### DIFF
--- a/contracts/erc2981/README.md
+++ b/contracts/erc2981/README.md
@@ -1,0 +1,5 @@
+# ERC2981 contract
+
+## Getting started
+
+ERC 2981 is a standard way to encode royalty information in a smart contract. This helps ensure that the NFT creator or rights holder gets paid the correct amount of royalties every time the NFT is sold or re-sold.

--- a/contracts/erc2981/contracts/ERC1155-example.sol
+++ b/contracts/erc2981/contracts/ERC1155-example.sol
@@ -1,0 +1,25 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts/token/common/ERC2981.sol";
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+contract ERC1155Example is ERC1155, ERC2981 {
+    constructor() ERC1155("ipfs://example/{id}.json") {
+        // set royalty of all NFTs to 5%
+        _setDefaultRoyalty(_msgSender(), 500);
+    }
+
+    function mint(
+        address to,
+        uint256 tokenId,
+        uint256 amount,
+        bytes memory data
+    ) public {
+        _mint(to, tokenId, amount, data);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC1155, ERC2981) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/erc2981/contracts/ERC721-example.sol
+++ b/contracts/erc2981/contracts/ERC721-example.sol
@@ -1,0 +1,20 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts/token/common/ERC2981.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract ERC721Example is ERC721, ERC2981 {
+    constructor() ERC721("Name", "Symbol") {
+        // set royalty of all NFTs to 5%
+        _setDefaultRoyalty(_msgSender(), 500);
+    }
+
+    function mint(address to, uint256 tokenId) public {
+        _safeMint(to, tokenId);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, ERC2981) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/erc2981/deploy/hardhat_deploy.ts
+++ b/contracts/erc2981/deploy/hardhat_deploy.ts
@@ -1,0 +1,16 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const myCollection = await ethers.deployContract("ERC721Example");
+
+  await myCollection.waitForDeployment();
+
+  console.log(`MyCollection was deployed to ${myCollection.target}`);
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/erc2981/test/erc1155.test.js
+++ b/contracts/erc2981/test/erc1155.test.js
@@ -1,0 +1,37 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ERC1155Example", function () {
+
+    it("Should deploy", async function () {
+        const Example = await ethers.getContractFactory("ERC1155Example");
+        this.example = await Example.deploy();
+        await this.example.deployed();
+
+        // check that the contract indicates it supports royalties
+        expect(await this.example.supportsInterface("0x2a55205a")).to.equal(true);
+    });
+
+    it("Should mint", async function () {
+        const [owner, wallet] = await ethers.getSigners();
+        const tokenId = 420;
+        const tokenAmount = 1;
+
+        await expect(this.example.mint(wallet.address, tokenId, tokenAmount, "0x", { from: owner.address }))
+            .to.emit(this.example, 'TransferSingle')
+            .withArgs(owner.address, ethers.constants.AddressZero, wallet.address, tokenId, tokenAmount);
+    });
+
+    it("Check global royalty", async function () {
+        const [owner] = await ethers.getSigners();
+
+        // "buy" an NFT for 100 Eth, to make percentage calculation easy
+        const salePrice = ethers.utils.parseEther("100");
+        // get the royalty information from the contract with the sale price
+        let [reciever, amount] = await this.example.royaltyInfo(420, salePrice);
+
+        // the owner should be getting 5% of the sale
+        expect(reciever).to.equal(owner.address);
+        expect(amount).to.equal(ethers.utils.parseEther("5"));
+    });
+});

--- a/contracts/erc2981/test/erc721.test.js
+++ b/contracts/erc2981/test/erc721.test.js
@@ -1,0 +1,39 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ERC721Example", function () {
+    let example;
+
+    it("Should deploy", async function () {
+        const Example = await ethers.getContractFactory("ERC721Example");
+        example = await Example.deploy();
+        await example.deployed();
+
+        expect(await example.name()).to.equal("Name");
+        expect(await example.symbol()).to.equal("Symbol");
+        // check that the contract indicates it supports royalties
+        expect(await example.supportsInterface("0x2a55205a")).to.equal(true);
+    });
+
+    it("Should mint", async function () {
+        const [_owner, wallet] = await ethers.getSigners();
+        const tokenId = 420;
+
+        await expect(example.mint(wallet.address, tokenId))
+            .to.emit(example, 'Transfer')
+            .withArgs(ethers.constants.AddressZero, wallet.address, tokenId);
+    });
+
+    it("Check global royalty", async function () {
+        const [owner] = await ethers.getSigners();
+
+        // "buy" an NFT for 100 Eth, to make percentage calculation easy
+        const salePrice = ethers.utils.parseEther("100");
+        // get the royalty information from the contract with the sale price
+        let [reciever, amount] = await example.royaltyInfo(420, salePrice);
+
+        // the owner should be getting 5% of the sale
+        expect(reciever).to.equal(owner.address);
+        expect(amount).to.equal(ethers.utils.parseEther("5"));
+    });
+});


### PR DESCRIPTION
[ERC 2981](https://eips.ethereum.org/EIPS/eip-2981) is a standard way to encode royalty information in a smart contract. This helps ensure that the NFT creator or rights holder gets paid the correct amount of royalties every time the NFT is sold or re-sold.

It is important to note that this is simply a standard. It is up to ecosystem particapts, namely marketplaces, to adhere to, respect, and ultimately pay the royalties using this information.